### PR TITLE
Javítás: Visszatérési típus deklaráció módosítása a verifyRequest metódusban

### DIFF
--- a/src/AppClient.php
+++ b/src/AppClient.php
@@ -24,9 +24,9 @@ class AppClient
      * @param string $time
      * @param string $token
      * @param string $hmac
-     * @return true|string true if request is verified, error message on fail
+     * @return bool|string true if request is verified, error message on fail
      */
-    public function verifyRequest(string $shop_id, string $time, string $token, string $hmac): true|string
+    public function verifyRequest(string $shop_id, string $time, string $token, string $hmac): bool|string
     {
         if (empty(trim($hmac))) {
             return 'empty hmac';


### PR DESCRIPTION
verifyRequest metódusban:


Hiba oka:
- A verifyRequest metódus visszatérési típusát "true|string"-ként definiáltuk, ami azt jelenti, hogy sikeres ellenőrzés esetén a függvény a literal "true" értéket adja vissza.
- A PHP azonban a "true" szót nem típusként kezeli, hanem mivel ez egy foglalt kulcsszó (boolean literál), a fordító megpróbálja osztályként értelmezni, ami fatal error-hoz vezet:  "Cannot use 'UnasOnline\UnasConnect\true' as class name as it is reserved".

Javítás:
- A visszatérési típus deklarációját módosítottam "bool|string"-re, így a metódus logikailag helyes típusokat használ:

  - "bool" jelzi, hogy siker esetén a metódus igaz (true) értékkel tér vissza.

  
Ez a módosítás megszünteti a konfliktust a PHP beépített kulcsszavával, és biztosítja, hogy a kód megfeleljen a nyelvi szabályoknak.
  
Tesztelve:
- A változtatás után a kód hibamentesen fut, és a várt működést biztosítja.